### PR TITLE
Broadcasting was added in Keras 2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Squeeze and Excitation Networks in Keras
-Implementation of [Squeeze and Excitation Networks](https://arxiv.org/pdf/1709.01507.pdf) in Keras 2.0+.
+Implementation of [Squeeze and Excitation Networks](https://arxiv.org/pdf/1709.01507.pdf) in Keras 2.0.3+.
 
 <img src="https://github.com/titu1994/keras-squeeze-excite-network/blob/master/images/squeeze-excite-block.JPG?raw=true" height=50% width=100%>
 


### PR DESCRIPTION
Without broadcasting the multiply() won't work and will complain about dimension mismatch.
`ValueError: Only tensors of same shape can be merged by ...`
https://github.com/fchollet/keras/pull/5812